### PR TITLE
Add Python gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.py[cod]
+.ipynb_checkpoints/
+
+.env
+.venv/
+venv/
+
+*.log
+*.pt
+*.pth
+*.h5
+
+outputs/
+results/


### PR DESCRIPTION
## Summary
- ignore Python cache files, virtual environments, notebook checkpoints, and common local outputs

## Notes
- config-only change; no runtime behavior change