### PR TITLE
Expand training artifact gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,14 @@ venv/
 *.pt
 *.pth
 *.h5
+*.keras
+*.ckpt
 
 outputs/
 results/
+checkpoints/
+data/
+embeddings/
+*.csv
+*.npy
+*.pkl


### PR DESCRIPTION
Adds ignore rules for checkpoints, Keras artifacts, local data, embeddings, CSV outputs, NumPy files, and pickle files.